### PR TITLE
Updating README for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Role Variables
 |`sysvinit_service_log_path`|str|`/var/log/{{ sysvinit_service_name }}.log`|path to create the log
 
 
-> * Required
+> \* Required
 
 Example Playbook
 ----------------


### PR DESCRIPTION
'*' under the table was being interpreted as a list item and not representative of the what it's supposed to be.